### PR TITLE
release: 0.0.2-alpha

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -18,6 +18,17 @@ jobs:
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org/'
+          cache: 'yarn'
+
+      - name: Verify package version matches release tag
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          RELEASE_TAG="${{ github.event.release.tag_name }}"
+          RELEASE_VERSION="${RELEASE_TAG#v}"
+          if [ "$PACKAGE_VERSION" != "$RELEASE_VERSION" ]; then
+            echo "Error: Package version ($PACKAGE_VERSION) does not match release tag ($RELEASE_VERSION)"
+            exit 1
+          fi
 
       - name: Install dependencies 
         run: yarn install --frozen-lockfile
@@ -25,13 +36,7 @@ jobs:
       - name: Build package
         run: yarn build
 
-      - name: Set version from release
-        run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
-          echo "Setting version to $VERSION"
-          npm version $VERSION --no-git-tag-version
-
       - name: Publish to NPM
-        run: npm publish
+        run: yarn publish --non-interactive
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uieh",
-  "version": "0.0.1-alpha",
+  "version": "0.0.2-alpha",
   "description": "Ui library for react",
   "author": "Adrien E.",
   "license": "MIT",


### PR DESCRIPTION
This pull request updates the release workflow and package versioning for the project. The main improvements are to ensure the package version always matches the release tag, and to streamline the publish process using `yarn`. The most important changes are grouped below:

**Release workflow improvements:**

* Added a step in `.github/workflows/npm-publish.yml` to verify that the `package.json` version matches the release tag, preventing mismatches between published versions and tags.
* Removed the workflow step that previously set the version from the release tag, as this is now enforced by the new verification step.

**Publishing process updates:**

* Changed the publish command from `npm publish` to `yarn publish --non-interactive` for consistency with the rest of the workflow.
* Enabled Yarn caching in the workflow to speed up dependency installation.

**Version bump:**

* Updated the version in `package.json` from `0.0.1-alpha` to `0.0.2-alpha`.